### PR TITLE
Don't run dependency tests when installing for CI

### DIFF
--- a/.github/workflows/perltest.yml
+++ b/.github/workflows/perltest.yml
@@ -27,5 +27,5 @@ jobs:
         with:
           perl-version: ${{ matrix.perl }}
       - run: perl -V
-      - run: cpanm --installdeps .
+      - run: cpanm --installdeps --notest .
       - run: prove -lv t


### PR DESCRIPTION
Because their test failures aren't our test failures and Test::Fatal
gets a SIGINT on Windows which causes Moose to fail to install which
causes us not to pass tests on Windows.